### PR TITLE
updated node versions in github actions

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -19,7 +19,7 @@ jobs:
       - name: "Setup Node"
         uses: "actions/setup-node@v2"
         with:
-          node-version: 16
+          node-version: 20
       - name: Update NPM
         run: npm install -g npm
       - name: "Version Bump"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
           cache: 'npm'
       - run: npm install
       - run: npm run build
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
           cache: 'npm'
       - run: npm install
       - run: npm run test
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
           cache: 'npm'
       - run: npm install
       - run: npm run lint
@@ -44,6 +44,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
           cache: 'npm'
       - run: npm audit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       - name: "Setup Node"
         uses: "actions/setup-node@v2"
         with:
-          node-version: 16
+          node-version: 20
       - name: Update NPM
         run: npm install -g npm
       - name: Install


### PR DESCRIPTION
fixes this [publishing crash](https://github.com/utily/cloudly-rest/actions/runs/7988598939/job/21813519542) 

```
Run npm install -g npm
npm ERR! code EBADENGINE
npm ERR! engine Unsupported engine
npm ERR! engine Not compatible with your version of node/npm: npm@10.4.0
npm ERR! notsup Not compatible with your version of node/npm: npm@10.4.0
npm ERR! notsup Required: {"node":"^18.17.0 || >=20.5.0"}
npm ERR! notsup Actual:   {"npm":"8.19.4","node":"v16.20.2"}

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/runner/.npm/_logs/2024-02-21T11_56_25_383Z-debug-0.log
Error: Process completed with exit code 1.
```